### PR TITLE
36333 Implemented rule single-module-file

### DIFF
--- a/checks/check_single_module_file.jl
+++ b/checks/check_single_module_file.jl
@@ -1,0 +1,45 @@
+module SingleModuleFile
+
+import JuliaSyntax: SyntaxNode, @K_str, children, haschildren, filename, kind
+using ...Properties: is_module, report_violation
+
+function check(modjule::SyntaxNode)
+    @assert kind(modjule) == K"module" "Expected a [module] node, got [$(kind(node))]."
+    father = modjule.parent
+    kids = children(father)
+    if kind(father) == K"toplevel"
+        mod_id = children(modjule)[1]
+        mod_name = string(mod_id)
+        file_name = basename(filename(modjule))[1:end-3]
+        if mod_name !== file_name
+            report_violation(mod_id, 5;
+                        user_msg="Module name, $mod_id, should match its file name, $file_name.",
+                        summary="A file in which a module is implemented should have the name of the module it contains.")
+        end
+        if length(kids) > 1
+            # This is not a submodule, and it has got siblings, which is bad, since
+            # the top-level module should contain the whole of the file's contents.
+            modules = filter(is_module, kids)
+            if modjule !== modules[1]
+                # Everything else below has already been reported
+                return nothing
+            end
+            mod_id = children(modules[1])[1]
+            name_1st_mod = string(mod_id)
+            for node in modules[2:end]  # all modules but the 1st
+                mod_id = children(node)[1]
+                mod_name = string(mod_id)
+                report_violation(mod_id, 5;
+                        user_msg="Module '$mod_name' should be inside '$name_1st_mod' or in its own file.",
+                        summary="Implement a maximum of one module per Julia file.")
+            end
+            for node in kids[kids .∉ Ref(modules)]
+                report_violation(node, 5;
+                        user_msg="Move this code into module '$name_1st_mod'.",
+                        summary="All code must be inside a module.")
+            end
+        end
+    end
+end
+
+end

--- a/src/Checks.jl
+++ b/src/Checks.jl
@@ -3,6 +3,7 @@ module Checks
 include("../checks/check_leading_and_trailing_digits.jl")
 include("../checks/check_function_identifiers_in_lower_snake_case.jl")
 include("../checks/check_struct_members_are_in_lower_snake_case.jl")
+include("../checks/check_single_module_file.jl")
 # include("../checks/check_avoid_globals.jl")
 # include("../checks/check_space_around_infix_operators.jl")
 

--- a/src/Process.jl
+++ b/src/Process.jl
@@ -55,6 +55,7 @@ function process(node::SyntaxNode)
 
         elseif is_module(node)
             #SymbolTable.enter_module(node)
+            Checks.SingleModuleFile.check(node)
 
         elseif is_operator(node)
             process_operator(node)


### PR DESCRIPTION
It checks that:
- The top-level module is alone in the file (no multiple top-level modules).
- Its name matches that of its containing file.
- There is not top-level code outside the module.