### PR TITLE
Fixed 2 fatal errors

### DIFF
--- a/checks/check_document_constants.jl
+++ b/checks/check_document_constants.jl
@@ -1,8 +1,8 @@
 module DocumentConstants
 
-using JuliaSyntax: SyntaxNode, @K_str, children, haschildren, kind
+using JuliaSyntax: SyntaxNode, @K_str, children, kind
 
-using ...Properties: report_violation
+using ...Properties: haschildren, report_violation
 
 export check
 

--- a/checks/check_function_arguments_in_lower_snake_case.jl
+++ b/checks/check_function_arguments_in_lower_snake_case.jl
@@ -1,12 +1,14 @@
 module FunctionArgumentsCasing
 
 import JuliaSyntax: SyntaxNode, @K_str, kind, children
-using ...Properties: is_lower_snake, report_violation
+using ...Properties: find_first_of_kind, is_lower_snake, report_violation
 
 function check(f_name::SyntaxNode, f_arg::SyntaxNode)
     @assert kind(f_name) == K"Identifier" "Expected argument 'f_name' to be an [Identifier], not $(kind(f_name))"
-    while kind(f_arg) != K"Identifier"
-        f_arg = children(f_arg)[1]
+    f_arg = find_first_of_kind(K"Identifier", f_arg)
+    if isnothing(f_arg)
+        # Nothing to check; probably a semicolon followed by nothing at all (nasty)
+        return nothing
     end
     arg_name = string(f_arg)
     if ! is_lower_snake(arg_name)

--- a/checks/check_infinite_while_loop.jl
+++ b/checks/check_infinite_while_loop.jl
@@ -1,7 +1,7 @@
 module InfiniteWhileLoop
 
-import JuliaSyntax: SyntaxNode, @K_str, kind, children, haschildren
-using ...Properties: report_violation
+import JuliaSyntax: SyntaxNode, @K_str, kind, children
+using ...Properties: haschildren, report_violation
 
 function check(wyle::SyntaxNode)
     @assert kind(wyle) == K"while" "Expected a [while], got $(kind(wyle))"

--- a/checks/check_module_name_casing.jl
+++ b/checks/check_module_name_casing.jl
@@ -1,7 +1,7 @@
 module ModuleNameCasing
 
-import JuliaSyntax: SyntaxNode, @K_str, children, haschildren, kind
-using ...Properties: is_upper_camel_case, report_violation
+import JuliaSyntax: SyntaxNode, @K_str, children, kind
+using ...Properties: haschildren, is_upper_camel_case, report_violation
 
 function check(modjule::SyntaxNode)
     @assert kind(modjule) == K"module" "Expected a [module] node, got [$(kind(node))]."

--- a/checks/check_single_module_file.jl
+++ b/checks/check_single_module_file.jl
@@ -1,7 +1,7 @@
 module SingleModuleFile
 
-import JuliaSyntax: SyntaxNode, @K_str, children, haschildren, filename, kind
-using ...Properties: is_module, report_violation
+import JuliaSyntax: SyntaxNode, @K_str, children, filename, kind
+using ...Properties: haschildren, is_module, report_violation
 
 function check(modjule::SyntaxNode)
     @assert kind(modjule) == K"module" "Expected a [module] node, got [$(kind(node))]."

--- a/src/Process.jl
+++ b/src/Process.jl
@@ -1,6 +1,6 @@
 module Process
 
-import JuliaSyntax: SourceFile, SyntaxNode, ParseError, @K_str, children, haschildren,
+import JuliaSyntax: SourceFile, SyntaxNode, ParseError, @K_str, children,
     kind, untokenize, JuliaSyntax as JS
 
 # include("SymbolTable.jl")
@@ -44,7 +44,7 @@ end
 
 
 function process(node::SyntaxNode)
-    if JS.haschildren(node)
+    if haschildren(node)
         if is_toplevel(node)
             #SymbolTable.enter_module()  # There is always the `Main` module
             # TODO: a file can be `include`d into another, thus into another

--- a/src/Properties.jl
+++ b/src/Properties.jl
@@ -1,12 +1,12 @@
 module Properties
 
-import JuliaSyntax: Kind, SyntaxNode, @K_str, @KSet_str, children, haschildren,
+import JuliaSyntax: Kind, SyntaxNode, @K_str, @KSet_str, children,
     head, kind, untokenize, JuliaSyntax as JS
 
-export MAX_LINE_LENGTH, opens_scope, closes_module, closes_scope, is_abstract,
-    is_assignment, is_constant, is_function, is_infix_operator, is_loop,
-    is_literal, is_lower_snake, is_module, is_operator, is_struct, is_toplevel,
-    is_union_decl, is_upper_camel_case, expr_depth, expr_size,
+export MAX_LINE_LENGTH, opens_scope, closes_module, closes_scope, haschildren,
+    is_abstract, is_assignment, is_constant, is_function, is_infix_operator,
+    is_loop, is_literal, is_lower_snake, is_module, is_operator, is_struct,
+    is_toplevel, is_union_decl, is_upper_camel_case, expr_depth, expr_size,
     find_first_of_kind, get_assignee, get_func_arguments, get_func_body,
     get_func_name, get_struct_members, get_struct_name, report_violation
 
@@ -33,6 +33,8 @@ function report_violation(node::SyntaxNode;
     printstyled(" $severity\n")
 end
 
+
+haschildren(node::JS.TreeNode) = JS.haschildren(node) && length(children(node)) > 0
 
 function is_lower_snake(s::AbstractString)
     return isnothing(match(r"[[:upper:]]", s))

--- a/tests/struct_members_are_in_lower_snake_case.jl
+++ b/tests/struct_members_are_in_lower_snake_case.jl
@@ -1,4 +1,4 @@
-struct point{T}
+struct Point{T}
     x::T
     y::T
 end

--- a/tests/test_rules.sh
+++ b/tests/test_rules.sh
@@ -17,7 +17,12 @@ err_code=0
 for test_file in tests/*.jl; do
     val_file=${test_file%.jl}.val
     [ -r "$val_file" ] || continue
-    if diff -q $val_file <( julia $JuliaCheck $test_file ) > /dev/null 2>&1
+    outfile=$( mktemp )
+    julia $JuliaCheck $test_file > $outfile
+    # This used to be done with `diff -q $val_file <( julia ... )`, but it caused
+    # an error with one of the input files. See here:
+    # https://github.com/julia-vscode/SymbolServer.jl/pull/120#issuecomment-2871798605
+    if diff -q $val_file $outfile > /dev/null 2>&1
     then
         echo "File '$test_file' checked."
     else


### PR DESCRIPTION
Fixed 2 fatal errors:
- Crash in cases like `func(x, y;)`.
- Fixed another crash pitfall: `haschildren` with an empty children list.
- Mysterious problem _in Julia_ with input process redirection (Bash feature), which affected the tests script. See [here](https://github.com/julia-vscode/SymbolServer.jl/pull/120#issuecomment-2871798605).
- Fixed one test file to keep an unrelated rule out.