### PR TITLE
Dependencies compatibility set (#36313)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,7 @@ authors = ["Juanma Bellon <juan.bellon@tiobe.com>"]
 version = "0.1.0"
 
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 
 [compat]
-Infiltrator = "1.8.8"
+JuliaSyntax = "1"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # JuliaCheck
 
 Code checker for Julia language, based on [JuliaSyntax](https://github.com/JuliaLang/JuliaSyntax.jl).
+
+This package is not listed in any registry yet, but it can be used, according to instructions from [this FAQ](https://github.com/JuliaRegistries/General#do-i-need-to-register-a-package-to-install-it), like this in the Julia REPL:
+```
+julia> ]
+
+... pkg> add https://github.com/tiobe/JuliaCheck
+```
+or like this, both in the REPL or in a Julia script:
+```
+using Pkg; Pkg.add(url="https://github.com/tiobe/JuliaCheck")
+```


### PR DESCRIPTION
- Set compatibility on `JuliaSyntax` dependency to "1", i.e., valid as long as the major version of that package is 1.
- Removed dependency on package `DataStructures` (that is for "Scoping" feature).
- Mention in `README.md` of how to install this package while it is not in any registry.

https://redmine.tiobe.com/issues/36313